### PR TITLE
Update settings.base.py

### DIFF
--- a/settings.base.py
+++ b/settings.base.py
@@ -154,6 +154,8 @@ settings = {
 	"as" :  # Artstation
 	{
 		# No password here.
+		"username"        : None,
+		"password"        : None,
 		"runInterval"     : days(2),
 		"dlDirName"       : "ArtStation",
 		"shortName"       : "as",


### PR DESCRIPTION
Finally came across an ArtStation account that I was interested in but when I uncommented out my ArtStation section it threw errors that it needed a username and password. I thought about coding in an exception for ArtStation, but I thought about it and it's generally a bad idea to code in special exceptions when simple solutions like this can be done instead. 

Alternatively, the artstation module could somehow pass a NoneType username/password to the settings array, but I'm not entirely sure how the loading process works.