### PR TITLE
TwitGet: file pattern from settings

### DIFF
--- a/xascraper/modules/twit/twitScrape.py
+++ b/xascraper/modules/twit/twitScrape.py
@@ -98,38 +98,38 @@ class GetTwit(xascraper.modules.scraper_base.ScraperBase):
 	# Timeline Scraping
 	# ---------------------------------------------------------------------------------------------------------------------------------------------------------
 
-	def _check_insert_tweet(self, src_artist, aid, tweet):
-		tweet_artist = tweet['tweet_author']
-		tweet_id     = tweet['tweetId']
+	def _check_insert_tweet(self, src_user, aid, tweet):
+		tw_user = tweet['tweet_author']
+		tw_id     = tweet['tweetId']
 
 		with self.db.context_sess() as sess:
-			is_new = self._upsert_if_new(sess, aid, tweet_id)
+			is_new = self._upsert_if_new(sess, aid, tw_id)
 
 		if is_new:
-			self.log.info("Have content for TweetID! %s, %s", tweet_id, src_artist)
+			self.log.info("Have content for TweetID! %s, %s", tw_id, src_user)
 			# return
 
 		tweet_entries = tweet['entries']
 
 		if tweet['isRetweet']:
-			tweet_title = "Retweet from %s by %s" % (tweet_artist, src_artist)
+			tw_title = "Retweet from %s by %s" % (tw_user, src_user)
 		else:
-			tweet_title = "Tweet from %s" % (tweet_artist, )
+			tw_title = "Tweet from %s" % (tw_user, )
 
 		self._updatePreviouslyRetreived(
-			artist             = src_artist,
-			release_meta       = tweet_id,
-			pageTitle          = tweet_title,
+			artist             = src_user,
+			release_meta       = tw_id,
+			pageTitle          = tw_title,
 			pageDesc           = tweet['text'],
 			postTags           = tweet_entries['hashtags'],
 			content_structured = tweet,
 			)
 
 		if tweet_entries['photos'] or tweet_entries['videos'] or tweet_entries['urls']:
-			self.setupDir(tweet_artist)
+			self.setupDir(tw_user)
 		else:
 			# Text-only tweet
-			self._updatePreviouslyRetreived(artist=src_artist, release_meta=tweet_id, state='complete')
+			self._updatePreviouslyRetreived(artist=src_user, release_meta=tw_id, state='complete')
 			return
 
 		photos = tweet_entries['photos']
@@ -138,17 +138,24 @@ class GetTwit(xascraper.modules.scraper_base.ScraperBase):
 
 		if urls and not (photos or videos):
 			self.log.warning("Urls entry on tweet (%s). Don't know how to handle this yet!", tweet_entries)
-			self._updatePreviouslyRetreived(artist=src_artist, release_meta=tweet_id, state='complete')
+			self._updatePreviouslyRetreived(artist=src_user, release_meta=tw_id, state='complete')
 			return
 		if videos and not (photos or urls):
 			self.log.warning("Videos entry on tweet (%s). Don't know how to handle this yet!", tweet_entries)
-			self._updatePreviouslyRetreived(artist=src_artist, release_meta=tweet_id, state='complete')
+			self._updatePreviouslyRetreived(artist=src_user, release_meta=tw_id, state='complete')
 			return
 
-		dlPathBase = self.getDownloadPath(self.dlBasePath, tweet_artist)
+		dlPathBase = self.getDownloadPath(self.dlBasePath, tw_user)
 
 		postd = datetime.datetime.fromtimestamp(tweet['time'])
-		postd = postd.isoformat().split("T")[0]
+		tw_y = postd.strftime('%y')
+		tw_m = int(postd.strftime('%m'))
+		tw_d = int(postd.strftime('%d'))
+		tw_ho = int(postd.strftime('%H'))
+		tw_mi = int(postd.strftime('%M'))
+		tw_se = int(postd.strftime('%S'))
+		tw_p = postd.strftime('%p')
+		tw_h = int(postd.strftime('%I'))
 
 		seq = 1
 		for url in photos:
@@ -156,11 +163,15 @@ class GetTwit(xascraper.modules.scraper_base.ScraperBase):
 			# if len(fName) == 0:
 			# 	raise FetchError("Missing Filename for file '%s' (url: %s)" % (fName, url))
 
-			fName = fName.split(":")[0]
+			fExt = (fName.rpartition(':')[0]).rpartition('.')[2]
+			fName = (fName.rpartition(':')[0]).rpartition('.')[0]
 
-			fName = "%s - %s - %s - %02i - %s" % (tweet_artist, tweet_id, postd, seq, fName)
+			try:
+				fName = str(eval(settings['twit']['filePattern']))
+			except KeyError:
+				fName = "%s - %s - 20%s-%02i-%02i - %02i - %s" % (tw_user, tw_id, tw_y, tw_m, tw_d, seq, fName)
 
-			filePath = os.path.join(dlPathBase, fName)
+			filePath = os.path.join(dlPathBase, (fName+'.'+fExt))
 
 			if isinstance(content, str):
 				content = content.encode(encoding='UTF-8')
@@ -169,10 +180,10 @@ class GetTwit(xascraper.modules.scraper_base.ScraperBase):
 			with open(filePath, "wb") as fp:
 				fp.write(content)
 
-			self._updatePreviouslyRetreived(artist=src_artist, release_meta=tweet_id, fqDlPath=filePath, seqNum=seq)
+			self._updatePreviouslyRetreived(artist=src_user, release_meta=tw_id, fqDlPath=filePath, seqNum=seq)
 			seq += 1
 
-		self._updatePreviouslyRetreived(artist=src_artist, release_meta=tweet_id, state='complete')
+		self._updatePreviouslyRetreived(artist=src_user, release_meta=tw_id, state='complete')
 
 
 


### PR DESCRIPTION
I have a ton of tweets I've scraped previously that use a different file pattern, so I figured it would be good to have a way of defining it in my settings instead of editing the source code after every update.

I renamed a lot of variables to shorter versions to help with configuring the pattern. For reference, what I use is `"filePattern" : "\"%s-%s-20%s%02i%02i_img%i\" % (tw_user, tw_id, tw_y, tw_m, tw_d, seq)"`