### PR TITLE
Enforce lowercase on adding new artist

### DIFF
--- a/xascraper/templates/watched-names-editor.html
+++ b/xascraper/templates/watched-names-editor.html
@@ -15,7 +15,7 @@
 				<input type="hidden" name="add", value="True">
 				<input type="hidden" name="site", value="{{sitename}}">
 				<div style="display: inline-block;">
-					<td><input type="text" name="artistName", value="" size=50></td>
+					<td><input type="text" name="artistName", value="" size=50 onkeyup="this.value = this.value.toLowerCase();"></td>
 				</div>
 				<input type="submit" value="Add">
 			</form>


### PR DESCRIPTION
As I learn more about pgsql, the more I'm annoyed with its sometimes-case-sensitive-sometimes-not design. Further, since SQLite seems to have some slightly different rules on this too. It's such a pain in the ass. So why not just make all the artist names lowercase?

One could set the column in SQLite to be defined as case insensitive, and in pgsql, add a trigger that makes all the data in the column lowercase, but I think the more uniform approach would be to simply enforce this on the `watched-named-editor.html` file, and rely on the dbFixer to convert already existing entries. In fact, I see that it already has a lowerCaseNames function defined.

To that end, it would be good if the fixer could get automatically triggered by certain commits. I have some ideas, but I bet you have better ones.