### PR TITLE
Exclude retweets from gen_tweets_for_date_span

### DIFF
--- a/xascraper/modules/twit/vendored_twitter_scrape.py
+++ b/xascraper/modules/twit/vendored_twitter_scrape.py
@@ -170,10 +170,10 @@ class TwitterFetcher(object):
 		from_date = start_date.isoformat()[:10]
 		to_date   = end_date.isoformat()[:10]
 
-		url = "https://twitter.com/search?q=from%3A{user}%20since%3A{from_date}%20until%3A{to_date}&src=typd".format(
+		url = "https://twitter.com/search?q=from%3A{user}%20since%3A{from_date}%20until%3A{to_date}%20-filter%3Aretweets&src=typd".format(
 			user=username, from_date=from_date, to_date=to_date)
 
-		url = "https://twitter.com/i/search/timeline?vertical=default&q=from%3A{user}%20since%3A{from_date}%20until%3A{to_date}&src=typd&include_available_features=1&include_entities=1&reset_error_state=false".format(
+		url = "https://twitter.com/i/search/timeline?vertical=default&q=from%3A{user}%20since%3A{from_date}%20until%3A{to_date}%20-filter%3Aretweets&src=typd&include_available_features=1&include_entities=1&reset_error_state=false".format(
 			user=username, from_date=from_date, to_date=to_date)
 
 		twit_headers = {


### PR DESCRIPTION
Excludes retweets from the search function using the filters documented [here](https://github.com/igorbrigadir/twitter-advanced-search).

As for the timeline, while there's an option documented [here](https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-user_timeline) to exclude retweets from the timeline, this is only visual for the end-user, it's still in the json object that's returned.