### PR TITLE
psycopg2-binary update to 2.8.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ flask-markdown==0.3
 dateparser==0.7.1
 markdown==3.1.1
 flask_login==0.4.1
-psycopg2-binary==2.8.3
+psycopg2-binary==2.8.4
 flask_csrf==0.9.2
 flask-paginate==0.5.3
 Flask-HTTPAuth==3.3.0


### PR DESCRIPTION
2.8.3 is incompatible with Python 3.8.x

I made a typo in the commit but whatever.