### PR TITLE
Tweak dump JSON output #2

### DIFF
--- a/manage/db_manage.py
+++ b/manage/db_manage.py
@@ -299,6 +299,7 @@ def export_db_contents(to_path, site_name):
 				tmp = (
 						uname,
 						post.title,
+						str(list(pfile.fspath for pfile in post.files)[0]),
 						post.content,
 						post.content_structured,
 						list(ptag.tag for ptag in post.tags),
@@ -308,7 +309,6 @@ def export_db_contents(to_path, site_name):
 								pfile.seqnum,
 								pfile.file_meta,
 								pfile.state,
-								pfile.fspath,
 								pfile.filename,
 							)
 							for pfile in post.files),


### PR DESCRIPTION
This was not missing from the original dump implementation, I separated it out so it would have its own key.

Nested arrays are very messy, and the fspath contains information that, unfortunately, isn't in any other  database key (for NG at least), so I need to capture strings with regex patterns from it.