### PR TITLE
TwitGet: Fix more ValueErrors

### DIFF
--- a/xascraper/modules/twit/vendored_twitter_scrape.py
+++ b/xascraper/modules/twit/vendored_twitter_scrape.py
@@ -119,7 +119,10 @@ class TwitterFetcher(object):
 					try:
 						video_id = tmp[:tmp.index('.jpg')]
 					except ValueError:
-						video_id = tmp[:tmp.index('.png')]
+						try:
+							video_id = tmp[:tmp.index('.png')]
+						except ValueError:
+							video_id = tmp[:tmp.index('?')]
 					videos.append({'id': video_id})
 
 		return {


### PR DESCRIPTION
This fixes even rarier ValueErrors where background-image-url is something like `https://pbs.twimg.com/card_img/1211841587879264256/pe7Js0cG?format=jpg&name=280x280`